### PR TITLE
srinidhi-dynamic functions

### DIFF
--- a/ast.ml
+++ b/ast.ml
@@ -50,6 +50,10 @@ type composition = {
   tracks: track list;
 }
 
+type expr =
+ | Ident   of string
+ | Member  of expr * string
+
 (* Statement types for our language *)
 type stmt =
   | CompDecl of string                           (* Composition testComp; *)
@@ -95,6 +99,35 @@ let string_of_stmt = function
       track_id ^ ".addSection(" ^ section_id ^ ");"
   | AddTrack (comp_id, track_id) ->
       comp_id ^ ".addTrack(" ^ track_id ^ ");"
+
+(* Utility to pull an identifier out of an expr of the form Var or Member(Var, _) *)
+let extract_id_of_expr = function
+ | Ident s -> s
+ | Member (Ident s, _) -> s
+ | _ -> failwith "Expected simple Ident or Member"
+
+ let find_function receiver_name method_name arg_expr =
+  (* get just the ID of the argument to pass into the stmt *)
+  let arg_id = extract_id_of_expr arg_expr in
+    match method_name with
+      | "addMeasures" ->
+          (* e.g. testSection.addMeasures(testMeasures.measures) *)
+          let measures_id = arg_id in
+          AddMeasures (receiver_name, measures_id)
+ 
+ 
+      | "addSection" ->
+          let section_id = arg_id in
+          AddSection (receiver_name, section_id)
+ 
+ 
+      | "addTrack" ->
+          let track_id = arg_id in
+          AddTrack (receiver_name, track_id)
+ 
+ 
+      | other ->
+          failwith ("Unknown method name in FindFunction: " ^ other) 
 
 let string_of_program stmts =
   "\n\nParsed program: \n\n" ^

--- a/ast.ml
+++ b/ast.ml
@@ -53,6 +53,7 @@ type composition = {
 type expr =
  | Ident   of string
  | Member  of expr * string
+ | IntLit  of int 
 
 (* Statement types for our language *)
 type stmt =
@@ -64,6 +65,7 @@ type stmt =
   | AddMeasures of string * string               (* testSection.addMeasures(testMeasures.measures); *)
   | AddSection of string * string                (* testTrack.addSection(testSection); *)
   | AddTrack of string * string                  (* testComp.addTrack(testTrack); *)
+  | SetKey of string * int                    (* testSection.setKey(100); *)
 
 (* Program is a list of statements *)
 type program = stmt list
@@ -99,12 +101,15 @@ let string_of_stmt = function
       track_id ^ ".addSection(" ^ section_id ^ ");"
   | AddTrack (comp_id, track_id) ->
       comp_id ^ ".addTrack(" ^ track_id ^ ");"
+  | SetKey (section_id, key) ->
+      section_id ^ ".setKey(" ^ string_of_int key ^ ");"
 
 (* Utility to pull an identifier out of an expr of the form Var or Member(Var, _) *)
 let extract_id_of_expr = function
  | Ident s -> s
  | Member (Ident s, _) -> s
- | _ -> failwith "Expected simple Ident or Member"
+ | IntLit i -> string_of_int i 
+ | _ -> failwith "Expected simple Ident, Member, or IntLit"
 
  let find_function receiver_name method_name arg_expr =
   (* get just the ID of the argument to pass into the stmt *)
@@ -124,7 +129,15 @@ let extract_id_of_expr = function
       | "addTrack" ->
           let track_id = arg_id in
           AddTrack (receiver_name, track_id)
- 
+      
+      | "setKey" ->
+        let key_value = match arg_expr with
+          | IntLit i -> i
+          | _ -> failwith "setKey expects an integer argument"
+          in
+          let () = Printf.printf "Parsed SetKey: %s -> %d\n%!"
+            receiver_name key_value in
+              SetKey (receiver_name, key_value)
  
       | other ->
           failwith ("Unknown method name in FindFunction: " ^ other) 

--- a/moozik.ml
+++ b/moozik.ml
@@ -17,7 +17,8 @@ some_notes
 	end;
 testSection.addMeasures(testMeasures.measures);
 testTrack.addSection(testSection);
-testComp.addTrack(testTrack); $" in
+testComp.addTrack(testTrack);
+testSection.setKey(100); $" in
   let lexbuf = Lexing.from_string  input in
   let program = Parser.program_rule Scanner.token lexbuf in
   print_endline (string_of_program program)

--- a/parser.mly
+++ b/parser.mly
@@ -12,7 +12,7 @@
 // %token <int> B_NOTE B_SHARP_NOTE B_FLAT_NOTE
 %token <int> R_NOTE
 %token COMPOSITION TRACK SECTION MEASURE
-%token DOT_MEASURES DOT_ADDMEASURES DOT_ADDSECTION DOT_ADDTRACK
+%token DOT
 %token NEW BEGIN END
 %token ASSIGN SEMICOLON LPAREN RPAREN LBRACKET RBRACKET COMMA
 %token EOF
@@ -20,6 +20,8 @@
 %start program_rule
 %type <Ast.program> program_rule
 %type <Ast.music_section> music_section
+%type <Ast.expr> expr
+
 
 %%
 
@@ -31,24 +33,24 @@ stmts:
   /* empty */ { [] }
 | stmt stmts { $1 :: $2 }
 
+expr:
+ | ID                { Ident $1 }
+ | ID DOT ID         { Member (Ident $1, $3) }
 
 stmt:
-  COMPOSITION ID ASSIGN NEW COMPOSITION LPAREN RPAREN SEMICOLON
-    { CompDecl($2) }
+ COMPOSITION ID ASSIGN NEW COMPOSITION LPAREN RPAREN SEMICOLON
+   { CompDecl($2) }
 | TRACK ID ASSIGN NEW TRACK LPAREN RPAREN SEMICOLON
-    { TrackDecl($2) }
+   { TrackDecl($2) }
 | SECTION ID ASSIGN NEW SECTION LPAREN RPAREN SEMICOLON
-    { SectionDecl($2) }
+   { SectionDecl($2) }
 | MEASURE ID ASSIGN NEW MEASURE LPAREN RPAREN SEMICOLON
-    { MeasureDecl($2) }
-| ID DOT_MEASURES ASSIGN BEGIN SEMICOLON music_section 
-    { MeasuresAssign($1, $6) }
-| ID DOT_ADDMEASURES LPAREN ID DOT_MEASURES RPAREN SEMICOLON
-    { AddMeasures($1, $4) }
-| ID DOT_ADDSECTION LPAREN ID RPAREN SEMICOLON
-    { AddSection($1, $4) }
-| ID DOT_ADDTRACK LPAREN ID RPAREN SEMICOLON
-    { AddTrack($1, $4) }
+   { MeasureDecl($2) }
+| ID DOT ID ASSIGN BEGIN SEMICOLON music_section
+   { if $3 = "measures" then MeasuresAssign($1, $7)
+     else failwith ("Unknown property: " ^ $3) }
+| ID DOT ID LPAREN expr RPAREN SEMICOLON
+   { find_function $1 $3 $5 }
 
 music_section:
 | music_stmts END SEMICOLON { $1 }

--- a/parser.mly
+++ b/parser.mly
@@ -4,6 +4,7 @@
 
 %token <string> ID
 %token <string> NOTE
+%token <int> INT  
 // %token <int> D_NOTE D_SHARP_NOTE D_FLAT_NOTE
 // %token <int> E_NOTE E_SHARP_NOTE E_FLAT_NOTE
 // %token <int> F_NOTE F_SHARP_NOTE F_FLAT_NOTE
@@ -35,6 +36,7 @@ stmts:
 
 expr:
  | ID                { Ident $1 }
+ | INT               { IntLit $1 }
  | ID DOT ID         { Member (Ident $1, $3) }
 
 stmt:

--- a/scanner.mll
+++ b/scanner.mll
@@ -10,6 +10,8 @@ let alpha = ['a'-'z' 'A'-'Z']
 let id = alpha (alpha | digit | '_')*
 let whitespace = [' ' '\t' '\r']
 let newline = '\n'
+let int = digit+
+
 
 rule token = parse
   | whitespace    { token lexbuf }
@@ -29,6 +31,7 @@ rule token = parse
   | ']'           { RBRACKET }
   | ','           { COMMA }
   | '.'           { DOT }
+  | int as num    { INT(int_of_string num) } 
   | note accidental digit as note { NOTE(note) }
   (* | 'c' '-' digit+ as note { 
       let dur = int_of_string (String.sub note 2 ((String.length note) - 2)) in
@@ -116,5 +119,5 @@ rule token = parse
     } *)
   | id as s       { ID(s) }
   | '$'           { print_endline("$ eof"); EOF }
-  | eof			  { print_endline("eof"); EOF }
+  | eof			      { print_endline("eof"); EOF }
   | _ as char     { raise (SyntaxError ("Unexpected character: " ^ Char.escaped char)) }

--- a/scanner.mll
+++ b/scanner.mll
@@ -18,10 +18,6 @@ rule token = parse
   | "Track"       { TRACK }
   | "Section"     { SECTION }
   | "Measure"     { MEASURE }
-  | ".measures"   { DOT_MEASURES }
-  | ".addMeasures"{ DOT_ADDMEASURES }
-  | ".addSection" { DOT_ADDSECTION }
-  | ".addTrack"   { DOT_ADDTRACK }
   | "new"         { NEW }
   | "begin"       { BEGIN }
   | "end"         { END }
@@ -32,6 +28,7 @@ rule token = parse
   | '['           { LBRACKET }
   | ']'           { RBRACKET }
   | ','           { COMMA }
+  | '.'           { DOT }
   | note accidental digit as note { NOTE(note) }
   (* | 'c' '-' digit+ as note { 
       let dur = int_of_string (String.sub note 2 ((String.length note) - 2)) in


### PR DESCRIPTION
took out hard coded scanner tokens for stuff like .addMeasures
replaced it with the rule: 
| ID DOT ID LPAREN expr RPAREN SEMICOLON
   { find_function $1 $3 $5 }

this find_function will now map the functions to their expected method names dynamically instead of relying on hard coded scanner tokens

Also added implementation for .setKey() which will take in an integer

EDIT: i just realized this doesn't yet support multi args for functions, but that can be implemented as we work through to implement the other functions from LRM